### PR TITLE
Camera etc

### DIFF
--- a/Assets/Characters.meta
+++ b/Assets/Characters.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 4b66e58de027f6d4d8df28871d4cdd50
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Materials/Water.meta
+++ b/Assets/Materials/Water.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 78dcc137a64108d4b8ea30e73d6863f3
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scenes/Scene1.unity
+++ b/Assets/Scenes/Scene1.unity
@@ -38,13 +38,13 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.12731749, g: 0.13414757, b: 0.1210787, a: 1}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 11
-  m_GIWorkflowMode: 0
+  m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1
@@ -1488,7 +1488,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   moveSpeed: 5
-  rotationSpeed: 75
+  rotationSpeed: 5
   jumpSpeed: 60
   gravity: 10
   buoyancy: 8
@@ -1602,10 +1602,6 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 4294967295
       objectReference: {fileID: 0}
-    - target: {fileID: 100000, guid: f2148076bd4644e4ba37aec9c82ec1db, type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
     - target: {fileID: 100004, guid: f2148076bd4644e4ba37aec9c82ec1db, type: 3}
       propertyPath: m_Layer
       value: 9
@@ -1703,6 +1699,10 @@ PrefabInstance:
       value: 4294967295
       objectReference: {fileID: 0}
     - target: {fileID: 100042, guid: f2148076bd4644e4ba37aec9c82ec1db, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: f2148076bd4644e4ba37aec9c82ec1db, type: 3}
       propertyPath: m_StaticEditorFlags
       value: 4294967295
       objectReference: {fileID: 0}
@@ -2783,9 +2783,7 @@ MonoBehaviour:
   points: []
   agent: {fileID: 1081271531}
   anim: {fileID: 1081271537}
-  stalkerRadius: 5
   wanderRadius: 6
-  wanderTimer: 5
 --- !u!195 &1081271531
 NavMeshAgent:
   m_ObjectHideFlags: 0
@@ -3528,7 +3526,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   target: {fileID: 240883161}
-  RotationSpeed: 1
+  invertYaxis: 0
 --- !u!1 &1567112826 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 100000, guid: fdee7aab57b2d06468db0b6cd5e19d07,
@@ -3857,9 +3855,7 @@ MonoBehaviour:
   points: []
   agent: {fileID: 1890322329}
   anim: {fileID: 1890322333}
-  stalkerRadius: 1.5
   wanderRadius: 6
-  wanderTimer: 2
 --- !u!1 &1937963962
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CameraFollow.cs
+++ b/Assets/Scripts/CameraFollow.cs
@@ -7,6 +7,7 @@ public class CameraFollow : MonoBehaviour {
     public GameObject target;  // The position that that camera will be following.
     public bool invertYaxis = false;
 
+    private PlayerCharacterController playerController;
     private float smoothing = 2f;
     private float rotationSpeed = 2.5f;
     private Vector3 basePositionOffset;  // The base distance from the target.
@@ -16,6 +17,7 @@ public class CameraFollow : MonoBehaviour {
 
     void Start()
     {
+        playerController = target.gameObject.GetComponent<PlayerCharacterController>();
         basePositionOffset = target.transform.position - transform.position;
         baseRotationOffset = target.transform.rotation.eulerAngles - transform.rotation.eulerAngles;
         handleSettings(invertYaxis);
@@ -46,12 +48,13 @@ public class CameraFollow : MonoBehaviour {
     {
         // The camera should not follow if the character is facing the camera
         Vector3 diff = this.target.transform.rotation.eulerAngles - this.transform.rotation.eulerAngles;
-        float angle = diff.y;
+        float angle = Mathf.Abs(diff.y);
         
         float range = 30f;
         float backwardsAngle = 180f;  // 180 degrees -> character is looking at the camera
-        bool isLookingAtCamera = angle < (backwardsAngle - range) || (backwardsAngle + range) > 210f;
-        return isLookingAtCamera;
+        bool isLookingAtCamera = angle > (backwardsAngle - range) && angle < (backwardsAngle + range);
+
+        return this.playerController.IsMoving() && !isLookingAtCamera;
     }
 
     void Follow()

--- a/Assets/Scripts/CameraFollow.cs
+++ b/Assets/Scripts/CameraFollow.cs
@@ -7,6 +7,7 @@ public class CameraFollow : MonoBehaviour {
     public GameObject target;  // The position that that camera will be following.
     public bool invertYaxis = false;
 
+    private float smoothing = 1f;
     private float rotationSpeed = 1f;
     private Vector3 offset;  // The initial offset from the target.
     private Vector3 rotation = Vector3.zero;
@@ -21,23 +22,23 @@ public class CameraFollow : MonoBehaviour {
     void Update()
     {
         float y = Input.GetAxis("Mouse Y");
-        HandleRotation(setInvYax * y * Settings.MouseSensitivity());
+        // HandleRotation(setInvYax * y * Settings.MouseSensitivity());
         SetCameraTransform();
     }
 
     void HandleRotation(float rotationValue)
     {
-        rotation.x += rotationValue * rotationSpeed;
-
-        // Limit the rotation to <-45: Down, 90: Up>
-        rotation.x = Mathf.Clamp(rotation.x, -15f, 50f);
-        Debug.Log(rotation.x);
+        float rotationX = rotationValue * rotationSpeed;
+        rotation.x = Mathf.Clamp(rotationX, -15f, 50f);
     }
 
     void SetCameraTransform()
     {
-        // Copy the target's transform
-        transform.SetPositionAndRotation(target.transform.position, target.transform.rotation);
+	Quaternion targetRotation = target.transform.rotation;
+	Quaternion baseRotation = transform.rotation;
+	float lerp = Time.deltaTime * smoothing;
+
+        transform.SetPositionAndRotation(target.transform.position, Quaternion.Lerp(baseRotation, targetRotation, lerp));
         
         transform.Rotate(rotation);
         

--- a/Assets/Scripts/PlayerCharacterController.cs
+++ b/Assets/Scripts/PlayerCharacterController.cs
@@ -6,7 +6,7 @@ public class PlayerCharacterController : MonoBehaviour {
 
     // Constants
     public float moveSpeed = 5.0f;
-    public float rotationSpeed = 125.0f;
+    public float rotationSpeed = 5.0f;
     public float jumpSpeed = 25.0f;
     public float gravity = 5.0f;
     public float buoyancy = 4.0f;
@@ -49,9 +49,12 @@ public class PlayerCharacterController : MonoBehaviour {
     void Update() {
         float h = Input.GetAxisRaw("Horizontal");
         float v = Input.GetAxisRaw("Vertical");
+        float alternative = Input.GetAxis("Fire2");
         bool j = Input.GetButtonDown("Jump");
-        float x = Input.GetAxis("Mouse X");
         
+        bool alternativeMovement = alternative != 0.0f;
+
+        // Up-Down movement
         if (j)
         {
             Jump();
@@ -59,12 +62,20 @@ public class PlayerCharacterController : MonoBehaviour {
 
         Fall();
         
-        HandleRotation(x * Settings.MouseSensitivity());
-        
-        HandleSideMovement(h);
-        
+        // Left-Right movement
+        if (!alternativeMovement)
+        {
+            HandleRotation(v, h);
+        }
+        else
+        {
+            HandleSideMovement(h);
+        }
+
+        // Front-Back movement
         MoveForward(v);
 
+        // Apply computed movement
         Move();
 
         // Set animations for movement
@@ -76,9 +87,13 @@ public class PlayerCharacterController : MonoBehaviour {
         speed.z = moveSpeed * v;
     }
 
-    void HandleRotation(float rotationValue)
+    void HandleRotation(float frontBack, float leftRight)
     {
-        rotation.y = rotationValue * rotationSpeed;
+        // Rotation is based on the ratio of frontBack and leftRight inputs
+        // If frontBack is 1 and leftRight is 1, the controller will rotate by 45 degrees to the left.
+        
+        float angle = Mathf.Atan2(leftRight, frontBack) * Mathf.Rad2Deg;
+        rotation.y = angle;
     }
 
     void HandleSideMovement(float inputValue)
@@ -109,7 +124,7 @@ public class PlayerCharacterController : MonoBehaviour {
     {
         // Apply movement vectors
         _controller.Move(transform.TransformDirection(speed * Time.deltaTime));
-        transform.Rotate(rotation * Time.deltaTime);
+        transform.Rotate(rotation * rotationSpeed * Time.deltaTime);
     }
 
     // Set parameters used in conditions of transitions in Animator component

--- a/Assets/Scripts/PlayerCharacterController.cs
+++ b/Assets/Scripts/PlayerCharacterController.cs
@@ -49,11 +49,8 @@ public class PlayerCharacterController : MonoBehaviour {
     void Update() {
         float h = Input.GetAxisRaw("Horizontal");
         float v = Input.GetAxisRaw("Vertical");
-        float alternative = Input.GetAxis("Fire2");
         bool j = Input.GetButtonDown("Jump");
         
-        bool alternativeMovement = alternative != 0.0f;
-
         // Up-Down movement
         if (j)
         {
@@ -63,15 +60,8 @@ public class PlayerCharacterController : MonoBehaviour {
         Fall();
         
         // Left-Right movement
-        if (!alternativeMovement)
-        {
-            HandleRotation(v, h);
-        }
-        else
-        {
-            HandleSideMovement(h);
-        }
-
+        HandleRotation(v, h);
+        
         // Front movement
         MoveForward(v, h);
 
@@ -94,14 +84,9 @@ public class PlayerCharacterController : MonoBehaviour {
     {
         // Rotation is based on the ratio of frontBack and leftRight inputs
         // If frontBack is 1 and leftRight is 1, the controller will rotate by 45 degrees to the left.
-        
+        // TODO: get a reference to the camera, rotate relative to camera's POV
         float angle = Mathf.Atan2(leftRight, frontBack) * Mathf.Rad2Deg;
         rotation.y = angle;
-    }
-
-    void HandleSideMovement(float inputValue)
-    {
-        speed.x = moveSpeed * inputValue;
     }
 
     void Jump()

--- a/Assets/Scripts/PlayerCharacterController.cs
+++ b/Assets/Scripts/PlayerCharacterController.cs
@@ -72,8 +72,8 @@ public class PlayerCharacterController : MonoBehaviour {
             HandleSideMovement(h);
         }
 
-        // Front-Back movement
-        MoveForward(v);
+        // Front movement
+        MoveForward(v, h);
 
         // Apply computed movement
         Move();
@@ -82,9 +82,12 @@ public class PlayerCharacterController : MonoBehaviour {
         Animating(v, h);
     }
 
-    void MoveForward(float v)
+    void MoveForward(float frontBack, float leftRight)
     {
-        speed.z = moveSpeed * v;
+        // Speed depends on the input with the largest amplitude, i.e.
+        // Trigger pushed all the way up or all the way left will result in the same speed
+        float magnitude = Mathf.Max(Mathf.Abs(frontBack), Mathf.Abs(leftRight));
+        speed.z = moveSpeed * magnitude;
     }
 
     void HandleRotation(float frontBack, float leftRight)

--- a/Assets/Scripts/PlayerCharacterController.cs
+++ b/Assets/Scripts/PlayerCharacterController.cs
@@ -121,4 +121,9 @@ public class PlayerCharacterController : MonoBehaviour {
         bool walking = h != 0f || v != 0f;
         anim.SetBool("IsWalking", walking);
     }
+
+    public bool IsMoving()
+    {
+        return this.speed.z != 0f;
+    }
 }


### PR DESCRIPTION
Można obracać kamerą niezależnie od ruchu gracza.
Na ten moment brakuje jeszcze ruchu gracza względem kamery (teraz obraca się względem własnej osi), przez co strzałka w dół powoduje kręcenie się w kółko zamiast ruchu w tył. Ale to się też zrobi.