### PR TITLE
Camera - shorten arm if obstacle detected

### DIFF
--- a/Assets/Scripts/ArmController.cs
+++ b/Assets/Scripts/ArmController.cs
@@ -3,13 +3,15 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class ArmController : MonoBehaviour {
+    public float optimalRadius = baseRadius;
+
     private Transform rotor;
     private Transform extender;
 
     // These values will be added to the externally provided transform params
-    private float baseRadius = 5.0f;
-    private float baseXRotation = 0f;
-    private float baseYRotation = 0f;
+    private static float baseRadius = 5.0f;
+    private static float baseXRotation = 0f;
+    private static float baseYRotation = 0f;
 
     // Limits
     private float xRotationLowerBound = 0f;
@@ -28,10 +30,17 @@ public class ArmController : MonoBehaviour {
         SetRotation(baseXRotation, baseYRotation);
     }
 
-    private void SetRadius(float radius)
+    public void SetRadius(float radius)
     {
+        // handle invalid Input
+        radius = Mathf.Max(radius, 0.1f);
         Vector3 position = new Vector3(0, 0, -radius);
         extender.localPosition = position;
+    }
+
+    public bool IsRadiusOptimal()
+    {
+        return extender.localPosition.z == optimalRadius;
     }
 
     private void SetRotation(float xRotation, float yRotation)

--- a/Assets/Scripts/CameraOperatorController.cs
+++ b/Assets/Scripts/CameraOperatorController.cs
@@ -38,8 +38,12 @@ public class CameraOperatorController : MonoBehaviour {
             follow.SetFollowRotation(false);
         }
 
+        // FIXME: this script should have full control over movement -> use Follow in manual mode
         float obstacleDistance = ObstacleDistance();
-        Debug.Log(obstacleDistance);
+        if (obstacleDistance != -1f)
+        {
+            arm.SetRadius(obstacleDistance - 0.1f);  // Set the camera radius a little bit in front of the obstacle
+        }
     }
 
     void HandleRotation(float rotationX, float rotationY)
@@ -80,10 +84,9 @@ public class CameraOperatorController : MonoBehaviour {
     // Detects objects between target and the camera
     RaycastHit[] DetectCollisions()
     {
-        Vector3 targetPosition = transform.position;
+        Vector3 targetPosition = follow.target.transform.position;
         Vector3 cameraPosition = camera.transform.position;
-        var distance = Vector3.Distance(cameraPosition, targetPosition);
-        return Physics.RaycastAll(targetPosition, cameraPosition - targetPosition, distance);
+        return Physics.RaycastAll(targetPosition, cameraPosition - targetPosition, arm.optimalRadius);
     }
 
     // Returns distance to the nearest object considered an obstacle

--- a/Assets/Scripts/CameraOperatorController.cs
+++ b/Assets/Scripts/CameraOperatorController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 public class CameraOperatorController : MonoBehaviour {
@@ -36,6 +37,9 @@ public class CameraOperatorController : MonoBehaviour {
         {
             follow.SetFollowRotation(false);
         }
+
+        float obstacleDistance = ObstacleDistance();
+        Debug.Log(obstacleDistance);
     }
 
     void HandleRotation(float rotationX, float rotationY)
@@ -71,5 +75,33 @@ public class CameraOperatorController : MonoBehaviour {
             setInvYax = -1;
         else
             setInvYax = 1;
+    }
+
+    // Detects objects between target and the camera
+    RaycastHit[] DetectCollisions()
+    {
+        Vector3 targetPosition = transform.position;
+        Vector3 cameraPosition = camera.transform.position;
+        var distance = Vector3.Distance(cameraPosition, targetPosition);
+        return Physics.RaycastAll(targetPosition, cameraPosition - targetPosition, distance);
+    }
+
+    // Returns distance to the nearest object considered an obstacle
+    // Returns -1 if no obstacle found
+    float ObstacleDistance()
+    {
+        var collisions = DetectCollisions();
+        float[] obstacles = (
+          from collision in collisions
+          where IsObstacle(collision.collider.gameObject)
+          select collision.distance
+        ).ToArray();
+
+        return obstacles.Any() ? obstacles.Min() : -1f;
+    }
+
+    bool IsObstacle(GameObject gameObject)
+    {
+        return gameObject.tag != "Player";
     }
 }


### PR DESCRIPTION
Powinno przybliżać kamerę do postaci jak kontroler wykryje, że coś zasłania widok.

Jeszcze czasem zdarzają się jakieś krzaki (np. przy obrocie kamery i jednoczesnym poruszaniu się postaci przy ścianie), ale cóż.